### PR TITLE
Support 2D and 3D segmentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The data format of the probability mask binary buffers is as follows:
 ##### 2D Segmentation masks
 
 If your model generates a 2D mask, i.e. a mask for a 2D image not a volume of images, then most of the previous section
- still applies with some modifications.
+still applies with some modifications.
 
 First, your JSON response should look like this:
 
@@ -144,7 +144,7 @@ First, your JSON response should look like this:
 }
 ```
 
-> Note: There is no need to specify `depth` and `timepoint` in `binary_data_shape` but there is a `dicom_image`
+> Note: There is no need to specify `depth` and `timepoints` in `binary_data_shape` but there is a `dicom_image`
 > object that allows identifying the image.
 
 > Also, `frame_number` is optional. Can be used for multi-frame instances.

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -29,12 +29,21 @@ from utils import load_image_data, sort_images
 def upload_study_me(file_path, is_segmentation_model, host, port):
     file_dict = []
     headers = {'Content-Type': 'multipart/related; '}
-    request_json = {'request': 'post', 
-                    'route': '/',
-                    'inference_command': 'get-probability-mask' if is_segmentation_model else 'get-bounding-box-2d'}
     
     images = load_image_data(file_path)
     images = sort_images(images)
+
+    if not is_segmentation_model:
+        inference_command = 'get-bounding-box-2d'
+    elif images[0].position is None:
+        # No spatial information available. Perform 2D segmentation
+        inference_command = 'get-probability-mask-2D'
+    else:
+        inference_command = 'get-probability-mask-3D'
+        
+    request_json = {'request': 'post', 
+                    'route': '/',
+                    'inference_command': inference_command}
 
     width = 0
     height = 0


### PR DESCRIPTION
Support 2D and 3D segmentation separately. 

It should now be possible to run `send_inference_request.sh` for both out of the box.