### PR TITLE
Update test tool

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -53,14 +53,12 @@ class InferenceSerializer():
                 logger.error('No binary type for JSON part {}'.format(i))
             except StopIteration:
                 logger.error('Ran out of binary components for JSON part {}'.format(i))
-
-            if binary_type in {'png_image'}:
-                # Binary blob is assumed to be a file pointer or buffer type
-                # to be read directly into the response
-                yield ('application/png', binary_blob.read())
-            elif binary_type in {'boolean_mask', 'probability_mask'}:
+            
+            if binary_type in {'probability_mask'}:
                 # Binary blob is a numpy array of any shape
                 yield ('application/binary', binary_blob.tostring())
+            else:
+                raise NotImplementedError("Binary type {} is not supported".format(binary_type))
 
 
 class Gateway(Flask):

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -39,12 +39,15 @@ def upload_study_me(file_path, model_type, host, port, output_folder):
     images = sort_images(images)
 
     if model_type == BOUNDING_BOX:
+        print("Performing bounding box prediction")
         inference_command = 'get-bounding-box-2d'
     elif model_type == SEGMENTATION_MODEL:
         if images[0].position is None:
             # No spatial information available. Perform 2D segmentation
+            print("Performing 2D mask segmentation")
             inference_command = 'get-probability-mask-2D'
         else:
+            print("Performing 3D mask segmentation")
             inference_command = 'get-probability-mask-3D'
     else:
         inference_command = 'other'

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -53,15 +53,10 @@ def upload_study_me(file_path, model_type, host, port, output_folder):
                     'route': '/',
                     'inference_command': inference_command}
 
-    width = 0
-    height = 0
     count = 0
     for image in images:
         try:
             dcm_file = pydicom.dcmread(image.path)
-            if width == 0 or height == 0:
-                width = dcm_file.Columns
-                height = dcm_file.Rows
             count += 1
             field = str(count)
             fo = open(image.path, 'rb').read()
@@ -71,10 +66,7 @@ def upload_study_me(file_path, model_type, host, port, output_folder):
             print('File {} is not a DICOM file'.format(image.path))
             continue
     
-    print('Sending {} files...'.format(count))
-    request_json['depth'] = count
-    request_json['height'] = height
-    request_json['width'] = width
+    print('Sending {} files...'.format(len(images)))
 
     file_dict.insert(0, ('request_json', ('request', json.dumps(request_json).encode('utf-8'), 'text/json')))
     

--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -60,22 +60,26 @@ def generate_images_with_masks(dicom_images, inference_results, output_folder):
         for mask_index, mask in enumerate(masks):
             # get mask for this image
             image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]
-            offset += dcm.Rows * dcm.Columns
             
             pixels = np.reshape(pixels, (-1, 3))
             assert image_mask.shape[0] == pixels.shape[0], \
-                f"The size of mask {mask_index} ({mask.shape}) does not match the size of the volume (slices x Rows x Columns)"
+                "The size of mask {} ({}) does not match the size of the volume (slices x Rows x Columns)".format(mask_index, mask.shape)
 
             # apply mask
             pixels[image_mask > 128] = pixels[image_mask > 128] * (1 - mask_alpha) + \
                 (mask_alpha * np.array(get_colors(mask_index, max_value)).astype(np.float)).astype(np.uint8)
-            
+
+        offset += dcm.Rows * dcm.Columns
+
         # write image to output folder
         output_filename = os.path.join(output_folder, str(index) + '_' + os.path.basename(os.path.normpath(image.path)))
         output_filename += '.png'
-        
+
         pixels = np.reshape(pixels, (dcm.Rows, dcm.Columns, 3))
         plt.imsave(output_filename, pixels)
+
+    for mask_index, mask in enumerate(masks):
+        assert mask.shape[0] == offset, "Mask {} does not have the same size ({}) as the volume ({})".format(mask_index, mask.shape[0], offset)
 
 def generate_images_for_single_image_masks(dicom_images, inference_results, output_folder):
     """ This function will save images to disk to preview how a mask looks on the input images.
@@ -102,7 +106,7 @@ def generate_images_for_single_image_masks(dicom_images, inference_results, outp
         image_mask = mask
         pixels = np.reshape(pixels, (-1, 3))
         assert image_mask.shape[0] == pixels.shape[0], \
-            f"The size of mask {index} ({image_mask.shape[0]}) does not match the size of the image ({pixels.shape[0]})"
+            "The size of mask {} ({}) does not match the size of the image ({})".format(index, image_mask.shape[0], pixels.shape[0])
 
         # apply mask
         pixels[image_mask > 128] = pixels[image_mask > 128] * (1 - mask_alpha) + \

--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -63,6 +63,9 @@ def generate_images_with_masks(dicom_images, inference_results, output_folder):
             offset += dcm.Rows * dcm.Columns
             
             pixels = np.reshape(pixels, (-1, 3))
+            assert image_mask.shape[0] == pixels.shape[0], \
+                f"The size of mask {mask_index} ({mask.shape}) does not match the size of the volume (slices x Rows x Columns)"
+
             # apply mask
             pixels[image_mask > 128] = pixels[image_mask > 128] * (1 - mask_alpha) + \
                 (mask_alpha * np.array(get_colors(mask_index, max_value)).astype(np.float)).astype(np.uint8)
@@ -98,6 +101,8 @@ def generate_images_for_single_image_masks(dicom_images, inference_results, outp
         # get mask for this image
         image_mask = mask
         pixels = np.reshape(pixels, (-1, 3))
+        assert image_mask.shape[0] == pixels.shape[0], \
+            f"The size of mask {index} ({image_mask.shape[0]}) does not match the size of the image ({pixels.shape[0]})"
 
         # apply mask
         pixels[image_mask > 128] = pixels[image_mask > 128] * (1 - mask_alpha) + \

--- a/mock_server.py
+++ b/mock_server.py
@@ -64,7 +64,9 @@ def get_bounding_box_2d_response(json_input, dicom_instances):
 def get_probability_mask_3D_response(json_input, dicom_instances):
     # Assuming that all files have the same size
     dcm = pydicom.read_file(dicom_instances[0])
-
+    depth = len(dicom_instances)
+    image_width = dcm.Columns
+    image_height = dcm.Rows
     response_json = {
         'protocol_version': '1.0',
         'parts': [
@@ -73,23 +75,23 @@ def get_probability_mask_3D_response(json_input, dicom_instances):
                 'binary_type': 'probability_mask',
                 'binary_data_shape': {
                     'timepoints': 1,
-                    'depth': len(dicom_instances),
-                    'width': dcm.Columns,
-                    'height': dcm.Rows
+                    'depth': depth,
+                    'width': image_width,
+                    'height': image_height
                 }
             }
         ]
     }
 
-    array_shape = (json_input['depth'], json_input['height'], json_input['width'])
-    
+    array_shape = (depth, image_height, image_width)
+
     # This code produces a mask that grows from the center of the image outwards as the image slices advance
     mask = numpy.zeros(array_shape, dtype=numpy.uint8)
-    mid_x = int(json_input['width'] / 2)
-    mid_y = int(json_input['height'] / 2)
-    for s in range(json_input['depth']):
-        offset_x = int(s / json_input['depth'] * mid_x)
-        offset_y = int(s / json_input['depth'] * mid_y)
+    mid_x = int(image_width / 2)
+    mid_y = int(image_height / 2)
+    for s in range(depth):
+        offset_x = int(s / depth * mid_x)
+        offset_y = int(s / depth * mid_y)
         indices = numpy.ogrid[mid_y - offset_y : mid_y + offset_y, mid_x - offset_x : mid_x + offset_x]
         mask[s][tuple(indices)] = 255
 


### PR DESCRIPTION
Some fixes and modifications for gateway, mock_server example and test tool:

* Support only `probability_mask` as `binary_type` (gateway.py)
* Remove file sizes from json_input in `run.py`. These values can be obtained from the files
* Add assert to validate that the output masks have the same shape as the input files