### PR TITLE
Support attachments in test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Inference model integration SDK
   - [Running Unit Tests](#running-unit-tests)
 - [Nifti image format support](#nifti-image-format-support)
 - [Secondary capture support](#secondary-capture-support)
+- [Sending attachments in the requests to the inference server](#sending-attachments-in-the-requests-to-the-inference-server)
 
 ## Integrating the SDK
 
@@ -453,4 +454,16 @@ If your model's output is a secondary capture DICOM file and you want to return 
       }
   ]
 }
+```
+
+## Sending attachments in the requests to the inference server
+
+If you need additional files to be sent with each request, such as a license file for example, then those files will be sent as multipart files.
+In the `mock_server.py` you will receive a JSON input and a list of files, as usual. 
+The list of files will include tha attachments at the front followed by the DICOM files to process.
+
+To test this with the test tool you can use the `-a` parameter to add any number of attachments like this:
+
+```bash
+./send-inference-request.sh -b --host 0.0.0.0 -p 8900 -f in/ -a some_attachment.txt other_attachment.bin
 ```

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Inference model integration SDK
   - [Containerization](#containerization)
 - [Testing the inference server](#testing-the-inference-server)
   - [To send an inference request to the mock inference server](#to-send-an-inference-request-to-the-mock-inference-server)
+    - [Sending attachments in the requests to the inference server](#sending-attachments-in-the-requests-to-the-inference-server)
   - [Running Unit Tests](#running-unit-tests)
 - [Nifti image format support](#nifti-image-format-support)
 - [Secondary capture support](#secondary-capture-support)
-- [Sending attachments in the requests to the inference server](#sending-attachments-in-the-requests-to-the-inference-server)
 
 ## Integrating the SDK
 
@@ -402,7 +402,7 @@ If you don't specify any arguments, a usage message will be shown.
 The script accepts the following parameters:
 
 ```
-./send-inference-request.sh [-h] [-s] [-b] [--host HOST] [--port PORT] /path/to/dicom/files
+./send-inference-request.sh [-h] [-s] [-b] [--host HOST] [--port PORT] [-i /path/to/dicom/files] [-a attachment1 ... attachmentN]
 ```
 
 Parameters:
@@ -410,6 +410,8 @@ Parameters:
 * `-s`: Use it if model is a segmentation model
 * `-b`: Use it if model is a bounding box model 
 * `--host` and `--port`: host and port of inference server
+* `-i`: Input files
+* `-a`: Add attachments to the request. Arguments should be paths to files.
 
 > PNG images will be generated and saved in the `inference-test-tool/output` directory as output of the test tool. 
 You can check if the model's output will be correctly displayed on the Arterys web app.
@@ -419,11 +421,24 @@ folder, you may send this study to your segmentation model listening on port 890
 command in the `inference-test-tool` directory:
 
 ```bash
-./send-inference-request.sh -s --host 0.0.0.0 --port 8900 ./study-folder/
+./send-inference-request.sh -s --host 0.0.0.0 --port 8900 -i ./study-folder/
 ```
 
 For this to work, the folder where you have your DICOM files (`study-folder` in this case) must be a subfolder of 
 `inference-test-tool` so that they will be accessible inside the docker container.
+
+#### Sending attachments in the requests to the inference server
+
+If you need additional files to be sent with each request, such as a license file for example, then those files will be sent as multipart files.
+In the `mock_server.py` you will receive a JSON input and a list of files, as usual. 
+The list of files will include tha attachments at the front followed by the DICOM files to process.
+
+To test this with the test tool you can use the `-a` parameter to add any number of attachments like this:
+
+```bash
+./send-inference-request.sh -b --host 0.0.0.0 -p 8900 -i in/ -a some_attachment.txt other_attachment.bin
+```
+
 
 ### Running Unit Tests
 
@@ -454,16 +469,4 @@ If your model's output is a secondary capture DICOM file and you want to return 
       }
   ]
 }
-```
-
-## Sending attachments in the requests to the inference server
-
-If you need additional files to be sent with each request, such as a license file for example, then those files will be sent as multipart files.
-In the `mock_server.py` you will receive a JSON input and a list of files, as usual. 
-The list of files will include tha attachments at the front followed by the DICOM files to process.
-
-To test this with the test tool you can use the `-a` parameter to add any number of attachments like this:
-
-```bash
-./send-inference-request.sh -b --host 0.0.0.0 -p 8900 -f in/ -a some_attachment.txt other_attachment.bin
 ```

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -94,17 +94,18 @@ def upload_study_me(file_path, model_type, host, port, output_folder, attachment
 
     json_response = json.loads(multipart_data.parts[0].text)
     print("JSON response:", json_response)
-    mask_count = len(json_response["parts"])
-
-    # Assert that we get one binary part for each object in 'parts'
-    # The additional two multipart object are: JSON response and request:response digests
-    assert mask_count == len(multipart_data.parts) - 2, \
-        "The server must return one binary buffer for each object in `parts`. Got {} buffers and {} 'parts' objects" \
-        .format(len(multipart_data.parts) - 2, mask_count)
-    
-    masks = [np.frombuffer(p.content, dtype=np.uint8) for p in multipart_data.parts[1:mask_count+1]]
 
     if model_type == SEGMENTATION_MODEL:
+        mask_count = len(json_response["parts"])
+
+        # Assert that we get one binary part for each object in 'parts'
+        # The additional two multipart object are: JSON response and request:response digests
+        assert mask_count == len(multipart_data.parts) - 2, \
+            "The server must return one binary buffer for each object in `parts`. Got {} buffers and {} 'parts' objects" \
+            .format(len(multipart_data.parts) - 2, mask_count)
+        
+        masks = [np.frombuffer(p.content, dtype=np.uint8) for p in multipart_data.parts[1:mask_count+1]]
+
         if images[0].position is None:
             # We must sort the images by their instance UID based on the order of the response:
             identifiers = [part['dicom_image']['SOPInstanceUID'] for part in json_response["parts"]]

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -131,7 +131,7 @@ def upload_study_me(file_path, model_type, host, port, output_folder, attachment
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--file_path", help="Path to dicom directory to upload.")
+    parser.add_argument("-i", "--input", help="Path to dicom directory to upload.")
     parser.add_argument("-s", "--segmentation_model", default=False, help="If the model's output is a segmentation mask", 
         action='store_true')
     parser.add_argument("-b", "--bounding_box_model", default=False, help="If the model's output are bounding boxes", 
@@ -147,4 +147,4 @@ def parse_args():
 if __name__ == '__main__':
     args = parse_args()
     model_type = SEGMENTATION_MODEL if args.segmentation_model else BOUNDING_BOX if args.bounding_box_model else OTHER
-    upload_study_me(args.file_path, model_type, args.host, args.port, args.output, args.attachments)
+    upload_study_me(args.input, model_type, args.host, args.port, args.output, args.attachments)

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -138,7 +138,7 @@ def parse_args():
     parser.add_argument("--host", default='arterys-inference-sdk-server', help="Host where inference SDK is hosted")
     parser.add_argument("-p", "--port", default='8000', help="Port of inference SDK host")
     parser.add_argument("-o", "--output", default='output', help="Folder where the script will save the response / output files")
-    parser.add_argument('-a', '--attachments', nargs='+', help='One or more paths to files add as attachments to the request')
+    parser.add_argument('-a', '--attachments', nargs='+', default=[], help='One or more paths to files add as attachments to the request')
     args = parser.parse_args()
     
     return args

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -31,7 +31,7 @@ SEGMENTATION_MODEL = "SEGMENTATION_MODEL"
 BOUNDING_BOX = "BOUNDING_BOX"
 OTHER = "OTHER"
 
-def upload_study_me(file_path, model_type, host, port, output_folder):
+def upload_study_me(file_path, model_type, host, port, output_folder, attachments):
     file_dict = []
     headers = {'Content-Type': 'multipart/related; '}
     
@@ -57,6 +57,13 @@ def upload_study_me(file_path, model_type, host, port, output_folder):
                     'inference_command': inference_command}
 
     count = 0
+    for att in attachments:
+        count += 1
+        field = str(count)
+        fo = open(att, 'rb').read()
+        filename = os.path.basename(os.path.normpath(att))
+        file_dict.append((field, (filename, fo, 'application/octet-stream')))
+
     for image in images:
         try:
             dcm_file = pydicom.dcmread(image.path)
@@ -131,6 +138,7 @@ def parse_args():
     parser.add_argument("--host", default='arterys-inference-sdk-server', help="Host where inference SDK is hosted")
     parser.add_argument("-p", "--port", default='8000', help="Port of inference SDK host")
     parser.add_argument("-o", "--output", default='output', help="Folder where the script will save the response / output files")
+    parser.add_argument('-a', '--attachments', nargs='+', help='One or more paths to files add as attachments to the request')
     args = parser.parse_args()
     
     return args
@@ -138,4 +146,4 @@ def parse_args():
 if __name__ == '__main__':
     args = parse_args()
     model_type = SEGMENTATION_MODEL if args.segmentation_model else BOUNDING_BOX if args.bounding_box_model else OTHER
-    upload_study_me(args.file_path, model_type, args.host, args.port, args.output)
+    upload_study_me(args.file_path, model_type, args.host, args.port, args.output, args.attachment)

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -130,7 +130,7 @@ def upload_study_me(file_path, model_type, host, port, output_folder, attachment
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("file_path", help="Path to dicom directory to upload.")
+    parser.add_argument("-f", "--file_path", help="Path to dicom directory to upload.")
     parser.add_argument("-s", "--segmentation_model", default=False, help="If the model's output is a segmentation mask", 
         action='store_true')
     parser.add_argument("-b", "--bounding_box_model", default=False, help="If the model's output are bounding boxes", 
@@ -146,4 +146,4 @@ def parse_args():
 if __name__ == '__main__':
     args = parse_args()
     model_type = SEGMENTATION_MODEL if args.segmentation_model else BOUNDING_BOX if args.bounding_box_model else OTHER
-    upload_study_me(args.file_path, model_type, args.host, args.port, args.output, args.attachment)
+    upload_study_me(args.file_path, model_type, args.host, args.port, args.output, args.attachments)

--- a/tests/test_2d_segmentation.py
+++ b/tests/test_2d_segmentation.py
@@ -13,7 +13,7 @@ class Test2DSegmentation(MockServerTestCase):
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
         result = subprocess.run(['./send-inference-request.sh', '-s', '--host', '0.0.0.0', '-p',
-            '8900', '-o', self.output_dir, self.input_dir], cwd='inference-test-tool',
+            '8900', '-o', self.output_dir, '-f', self.input_dir], cwd='inference-test-tool',
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
         
         # Test that the command executed successfully

--- a/tests/test_3d_segmentation.py
+++ b/tests/test_3d_segmentation.py
@@ -14,7 +14,7 @@ class Test3DSegmentation(MockServerTestCase):
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
         result = subprocess.run(['./send-inference-request.sh', '-s', '--host', '0.0.0.0', '-p',
-            '8900', '-o', self.output_dir, self.input_dir], cwd='inference-test-tool',
+            '8900', '-o', self.output_dir, '-f', self.input_dir], cwd='inference-test-tool',
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
         
         # Test that the command executed successfully

--- a/tests/test_bounding_boxes.py
+++ b/tests/test_bounding_boxes.py
@@ -13,7 +13,7 @@ class TestBoundingBox(MockServerTestCase):
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
         result = subprocess.run(['./send-inference-request.sh', '-b', '--host', '0.0.0.0', '-p',
-            '8900', '-o', self.output_dir, self.input_dir], cwd='inference-test-tool',
+            '8900', '-o', self.output_dir, '-f', self.input_dir], cwd='inference-test-tool',
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
         
         # Test that the command executed successfully


### PR DESCRIPTION
Attachments are sent as multipart objects using indexes 1...

Usage:

```bash
./send-inference-request.sh -b --host 0.0.0.0 -p 8900 -f in/ -a some_attachment.txt
```

TODO:

- [x] Add docs to Readme