### PR TITLE
Fix opencv version

### DIFF
--- a/inference-test-tool/requirements.txt
+++ b/inference-test-tool/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==3.1.3
 numpy==1.18.1
 Pillow==7.2.0
-opencv-python
+opencv-python==4.3.0.36
 pydicom==1.4.1
 requests==2.22.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
Running Unittests caused the following error:
```
Traceback (most recent call last):
  File "run.py", line 25, in <module>
    import test_inference_mask
  File "/opt/test_inference_mask.py", line 13, in <module>
    import cv2
  File "/home/inference-user/.local/lib/python3.7/site-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```
Which was solved by pinning opencv to an older version.