### PR TITLE
Allow 2D SC to not match the UID of an image

### DIFF
--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -133,8 +133,9 @@ def upload_study_me(file_path, model_type, host, port, output_folder, attachment
             identifiers = [part['dicom_image']['SOPInstanceUID'] for part in json_response["parts"]]
             filtered_images = []
             for id in identifiers:
-                image = next((img for img in images if img.instanceUID == id))
-                filtered_images.append(image)
+                image = next((img for img in images if img.instanceUID == id), None)
+                if image:
+                    filtered_images.append(image)
             test_inference_mask.generate_images_for_single_image_masks(filtered_images, masks, json_response, output_folder)
         else:
             test_inference_mask.generate_images_with_masks(images, masks, json_response, output_folder)

--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -103,36 +103,35 @@ def generate_images_with_masks(dicom_images, inference_results, response_json, o
 
     offset = 0
 
-    if non_sc_masks:
-        for index, image in enumerate(images):
-            dcm = pydicom.dcmread(image.path)
-            pixels = get_pixels(dcm)
+    for index, image in enumerate(images):
+        dcm = pydicom.dcmread(image.path)
+        pixels = get_pixels(dcm)
 
-            # Reshape and add alpha
-            pixels = np.reshape(pixels, (-1, 3))
+        # Reshape and add alpha
+        pixels = np.reshape(pixels, (-1, 3))
+        pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
+
+        for mask_index, (mask, json_part) in enumerate(zip(non_sc_masks, all_mask_parts)):
+            # If the input holds multiple timepoints but the result only includes 1 timepoint
+            if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
+                continue
+            # get mask for this image
+            image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]
+            pixels = _draw_mask_on_image(pixels, image_mask, json_part, response_json, mask_index, mask_index)
+
+        offset += dcm.Rows * dcm.Columns
+
+        # write image to output folder
+        output_filename = os.path.join(output_folder, str(index) + '_' + os.path.basename(os.path.normpath(image.path)))
+        output_filename += '.png'
+
+        if pixels.shape[1] != 4:
             pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
+        pixels = np.reshape(pixels, (dcm.Rows, dcm.Columns, 4))
+        plt.imsave(output_filename, pixels)
 
-            for mask_index, (mask, json_part) in enumerate(zip(non_sc_masks, all_mask_parts)):
-                # If the input holds multiple timepoints but the result only includes 1 timepoint
-                if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
-                    continue
-                # get mask for this image
-                image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]
-                pixels = _draw_mask_on_image(pixels, image_mask, json_part, response_json, mask_index, mask_index)
-
-            offset += dcm.Rows * dcm.Columns
-
-            # write image to output folder
-            output_filename = os.path.join(output_folder, str(index) + '_' + os.path.basename(os.path.normpath(image.path)))
-            output_filename += '.png'
-
-            if pixels.shape[1] != 4:
-                pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
-            pixels = np.reshape(pixels, (dcm.Rows, dcm.Columns, 4))
-            plt.imsave(output_filename, pixels)
-
-        for mask_index, mask in enumerate(non_sc_masks):
-            assert mask.shape[0] <= offset, "Mask {} does not have the same size ({}) as the volume ({})".format(mask_index, mask.shape[0], offset)
+    for mask_index, mask in enumerate(non_sc_masks):
+        assert mask.shape[0] <= offset, "Mask {} does not have the same size ({}) as the volume ({})".format(mask_index, mask.shape[0], offset)
 
 def generate_images_for_single_image_masks(dicom_images, inference_results, response_json, output_folder):
     """ This function will save images to disk to preview how a mask looks on the input images.

--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -102,35 +102,37 @@ def generate_images_with_masks(dicom_images, inference_results, response_json, o
         pydicom.dcmwrite(file_path, dcm)
 
     offset = 0
-    for index, image in enumerate(images):
-        dcm = pydicom.dcmread(image.path)
-        pixels = get_pixels(dcm)
 
-        # Reshape and add alpha
-        pixels = np.reshape(pixels, (-1, 3))
-        pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
+    if non_sc_masks:
+        for index, image in enumerate(images):
+            dcm = pydicom.dcmread(image.path)
+            pixels = get_pixels(dcm)
 
-        for mask_index, (mask, json_part) in enumerate(zip(non_sc_masks, all_mask_parts)):
-            # If the input holds multiple timepoints but the result only includes 1 timepoint
-            if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
-                continue
-            # get mask for this image
-            image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]
-            pixels = _draw_mask_on_image(pixels, image_mask, json_part, response_json, mask_index, mask_index)
-
-        offset += dcm.Rows * dcm.Columns
-
-        # write image to output folder
-        output_filename = os.path.join(output_folder, str(index) + '_' + os.path.basename(os.path.normpath(image.path)))
-        output_filename += '.png'
-
-        if pixels.shape[1] != 4:
+            # Reshape and add alpha
+            pixels = np.reshape(pixels, (-1, 3))
             pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
-        pixels = np.reshape(pixels, (dcm.Rows, dcm.Columns, 4))
-        plt.imsave(output_filename, pixels)
 
-    for mask_index, mask in enumerate(non_sc_masks):
-        assert mask.shape[0] <= offset, "Mask {} does not have the same size ({}) as the volume ({})".format(mask_index, mask.shape[0], offset)
+            for mask_index, (mask, json_part) in enumerate(zip(non_sc_masks, all_mask_parts)):
+                # If the input holds multiple timepoints but the result only includes 1 timepoint
+                if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
+                    continue
+                # get mask for this image
+                image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]
+                pixels = _draw_mask_on_image(pixels, image_mask, json_part, response_json, mask_index, mask_index)
+
+            offset += dcm.Rows * dcm.Columns
+
+            # write image to output folder
+            output_filename = os.path.join(output_folder, str(index) + '_' + os.path.basename(os.path.normpath(image.path)))
+            output_filename += '.png'
+
+            if pixels.shape[1] != 4:
+                pixels = np.hstack((pixels, np.reshape(np.full(pixels.shape[0], 255, dtype=np.uint8), (-1, 1))))
+            pixels = np.reshape(pixels, (dcm.Rows, dcm.Columns, 4))
+            plt.imsave(output_filename, pixels)
+
+        for mask_index, mask in enumerate(non_sc_masks):
+            assert mask.shape[0] <= offset, "Mask {} does not have the same size ({}) as the volume ({})".format(mask_index, mask.shape[0], offset)
 
 def generate_images_for_single_image_masks(dicom_images, inference_results, response_json, output_folder):
     """ This function will save images to disk to preview how a mask looks on the input images.
@@ -149,7 +151,7 @@ def generate_images_for_single_image_masks(dicom_images, inference_results, resp
     create_folder(output_folder)
 
     # Filter out secondary capture outputs
-    all_mask_parts = [p for p in response_json["parts"] if p['binary_type'] not in  DICOM_BINARY_TYPES]
+    all_mask_parts = [p for p in response_json["parts"] if p['binary_type'] not in DICOM_BINARY_TYPES]
     secondary_capture_indexes = [i for (i,p) in enumerate(response_json["parts"]) if p['binary_type'] in DICOM_BINARY_TYPES]
     masks = np.array(masks)
     secondary_capture_indexes_bool = np.in1d(range(masks.shape[0]), secondary_capture_indexes)


### PR DESCRIPTION
SC might be unrelated to input dcm files so SOPInstanceUID doesn't need to match.