### PR TITLE
Add support for multi series inference

### DIFF
--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -100,9 +100,9 @@ def generate_images_with_masks(dicom_images, inference_results, response_json, o
     images_by_series = group_by_series(images)
     series = images_by_series.keys()
 
-    for serie in series:
+    for series_uid in series:
         offset = 0
-        for index, image in enumerate(images_by_series[serie]):
+        for index, image in enumerate(images_by_series[series_uid]):
             dcm = pydicom.dcmread(image.path)
             pixels = get_pixels(dcm)
 
@@ -114,7 +114,7 @@ def generate_images_with_masks(dicom_images, inference_results, response_json, o
                 # If the input holds multiple timepoints but the result only includes 1 timepoint
                 if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
                     continue
-                if ('SeriesInstanceUID' in json_part) and json_part['SeriesInstanceUID'] != serie:
+                if ('SeriesInstanceUID' in json_part) and json_part['SeriesInstanceUID'] != series_uid:
                     # This mask does not apply to this series
                     continue
                 # get mask for this image

--- a/inference-test-tool/test_inference_mask.py
+++ b/inference-test-tool/test_inference_mask.py
@@ -114,7 +114,8 @@ def generate_images_with_masks(dicom_images, inference_results, response_json, o
                 # If the input holds multiple timepoints but the result only includes 1 timepoint
                 if image.timepoint is not None and image.timepoint > 0 and json_part['binary_data_shape']['timepoints'] == 1:
                     continue
-                if json_part['SeriesInstanceUID'] != serie:
+                if ('SeriesInstanceUID' in json_part) and json_part['SeriesInstanceUID'] != serie:
+                    # This mask does not apply to this series
                     continue
                 # get mask for this image
                 image_mask = mask[offset : offset + dcm.Rows * dcm.Columns]

--- a/mock_server.py
+++ b/mock_server.py
@@ -57,11 +57,11 @@ def get_classification_response(json_input, dicom_instances):
                 'value': '0.9',
                 'nested_labels': {
                     'condition1': '0.9',
-                    'condition2': '0.2', 
+                    'condition2': '0.2',
                     'condition3': '0.22'
                 }
             }
-        }, 
+        },
         'study_ml_json': {
             'label1': 'condition1',
             'label2': 'condition2'
@@ -102,7 +102,8 @@ def get_probability_mask_3D_response(json_input, dicom_instances):
                     'depth': depth,
                     'width': image_width,
                     'height': image_height
-                }
+                },
+                'SeriesInstanceUID': dcm.SeriesInstanceUID
             }
         ]
     }
@@ -198,7 +199,7 @@ def parse_args():
     group.add_argument("-b", "--bounding_box_model", default=False, help="If the model's output are bounding boxes",
         action='store_true')
     group.add_argument("-cl", "--classification_model", default=False, help="If the model's output are labels",
-        action='store_true')  
+        action='store_true')
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
This PR adds support for inference models that accept multiple input series and return binary masks for one or more of them. Previously, the test tool intended to apply the mask on all input images without validating the series UID