### PR TITLE
Update SDK to handle multiple output types for a single model

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ For an example, the `write_dataset_to_bytes` function on [this Pydicom help page
 
 ##### DICOM structured report
 
-If your model returns a DICOM Structured Report then do the same as for secondary captures explained in the previous section, just change `'binary_type'` to `'dicom'`.
+If your model returns a DICOM Structured Report then do the same as for secondary captures explained in the previous section, just change `'binary_type'` to `'dicom_structured_report'`.
 
 ##### Returning DICOM conformance errors
 

--- a/README.md
+++ b/README.md
@@ -410,14 +410,12 @@ docker logs -f <name of the container>
 curl localhost:8900/healthcheck
 ```
 
-For `<command>` pass `-b` for bounding boxes, `-s3D` for 3D segmentation, `-s2D` for 2D segmentation, depending on what type of result your model produces.
-
 If you want to pass additional flags to the `docker run` command which is run in `start_server.sh` then you can pass all of them behind the `command`.
 
 For example, to run the container in background, and add access to GPU:
 
 ```bash
-./start_server.sh -b -d --gpus=all
+./start_server.sh -d --gpus=all
 ```
 
 While developing it might also be handy to add a volume with the current directory to speed up the test cycle.
@@ -506,22 +504,23 @@ If you don't specify any arguments, a usage message will be shown.
 The script accepts the following parameters:
 
 ```
-./send-inference-request.sh [-h] [-s] [-b] [-cl] [-l] [--host HOST] [--port PORT] [-i /path/to/dicom/files] [-a attachment1 ... attachmentN] [-S] [-c INFERENCE_COMMAND]
+./send-inference-request.sh [-h] [-i INPUT] [-l] [--host HOST] [-p PORT] [-o OUTPUT]
+              [-a ATTACHMENTS [ATTACHMENTS ...]] [-S] [-c INFERENCE_COMMAND]
+              [-r ROUTE] [--request_study_path REQUEST_STUDY_PATH]
+              [-C ENCODED_CONFIG_XML] [-K PLWMKEY]
 ```
 
 Parameters:
 * `-h`: Print usage help
-* `-s`: Use it if model is a segmentation model
-* `-b`: Use it if model is a bounding box model
-* `-cl`: Use it if model is a classification model
 * `-l`: Use it if you want to generate PNG images with labels plotted on top of them (only applies to classification models)
 * `--host` and `--port`: host and port of inference server
 * `-i`: Input files
 * `-a`: Add attachments to the request. Arguments should be paths to files.
 * `-S`: If the study size should be send in the request JSON
 * `-c`: If set, overrides the 'inference_command' send in the request
-* `--send_only_study_path`: If set, only the study path is sent to the inference SDK, rather than the study images being sent through HTTP. When set, ensure volumes are mounted appropriately in the inference docker container
+* `--request_study_path`: If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. When set, ensure volumes are mounted appropriately in the inference docker container
 * `-C`: Optional encoded XML config to be passed as encodedConfigXML in request JSON
+* `-K`: Optional base64 encoded license key, only required for some models
 
 > PNG images will be generated and saved in the `inference-test-tool/output` directory as output of the test tool.
 You can check if the model's output will be correctly displayed on the Arterys web app.
@@ -533,7 +532,7 @@ folder, you may send this study to your segmentation model listening on port 890
 command in the `inference-test-tool` directory:
 
 ```bash
-./send-inference-request.sh -s --host 0.0.0.0 --port 8900 -i ./study-folder/
+./send-inference-request.sh --host 0.0.0.0 --port 8900 -i ./study-folder/
 ```
 
 For this to work, the folder where you have your DICOM files (`study-folder` in this case) must be a subfolder of
@@ -548,7 +547,7 @@ The list of files will include tha attachments at the front followed by the DICO
 To test this with the test tool you can use the `-a` parameter to add any number of attachments like this:
 
 ```bash
-./send-inference-request.sh -b --host 0.0.0.0 -p 8900 -i in/ -a some_attachment.txt other_attachment.bin
+./send-inference-request.sh --host 0.0.0.0 -p 8900 -i in/ -a some_attachment.txt other_attachment.bin
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -520,6 +520,8 @@ Parameters:
 * `-a`: Add attachments to the request. Arguments should be paths to files.
 * `-S`: If the study size should be send in the request JSON
 * `-c`: If set, overrides the 'inference_command' send in the request
+* `--send_only_study_path`: If set, only the study path is sent to the inference SDK, rather than the study images being sent through HTTP. When set, ensure volumes are mounted appropriately in the inference docker container
+* `-C`: Optional encoded XML config to be passed as encodedConfigXML in request JSON
 
 > PNG images will be generated and saved in the `inference-test-tool/output` directory as output of the test tool.
 You can check if the model's output will be correctly displayed on the Arterys web app.

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ The script accepts the following parameters:
 ./send-inference-request.sh [-h] [-i INPUT] [-l] [--host HOST] [-p PORT] [-o OUTPUT]
               [-a ATTACHMENTS [ATTACHMENTS ...]] [-S] [-c INFERENCE_COMMAND]
               [-r ROUTE] [--request_study_path REQUEST_STUDY_PATH]
-              [-C ENCODED_CONFIG_XML] [-K PLWMKEY]
+              [--request_options KEY=VALUE [KEY=VALUE ...]]
 ```
 
 Parameters:
@@ -519,8 +519,10 @@ Parameters:
 * `-S`: If the study size should be send in the request JSON
 * `-c`: If set, overrides the 'inference_command' send in the request
 * `--request_study_path`: If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. When set, ensure volumes are mounted appropriately in the inference docker container
-* `-C`: Optional encoded XML config to be passed as encodedConfigXML in request JSON
-* `-K`: Optional base64 encoded license key, only required for some models
+*  `--request_options`: Set a number of key-value pairs to be sent in the request JSON (do not put spaces before or after the = sign).
+                        If a value contains spaces, you should define it with double quotes.
+                        Values are always treated as strings.
+                        e.g. --request_options foo=bar a=b greeting="hello there"
 
 > PNG images will be generated and saved in the `inference-test-tool/output` directory as output of the test tool.
 You can check if the model's output will be correctly displayed on the Arterys web app.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ The SDK helps you containerize your model into a Flask app with a predefined API
   - [The healthcheck endpoint](#the-healthcheck-endpoint)
   - [Handling an inference request](#handling-an-inference-request)
     - [Standard model outputs](#standard-model-outputs)
+      - [Bounding box](#bounding-box)
+      - [Classification labels (and other additional information)](#classification-labels-and-other-additional-information)
+      - [Segmentation masks](#segmentation-masks)
+        - [Probability mask for 3D Series](#probability-mask-for-3d-series)
+        - [Boolean mask for 3D Series](#boolean-mask-for-3d-series)
+        - [Heatmaps for 3D series](#heatmaps-for-3d-series)
+        - [Heatmaps for 2D series (e.g. X-Rays)](#heatmaps-for-2d-series-eg-x-rays)
+        - [Numeric label mask for 3D series](#numeric-label-mask-for-3d-series)
+      - [Linear measurements](#linear-measurements)
+      - [Secondary capture support](#secondary-capture-support)
+      - [DICOM structured report](#dicom-structured-report)
+      - [Returning DICOM conformance errors](#returning-dicom-conformance-errors)
     - [Request JSON format](#request-json-format)
   - [Build and run the mock inference service container](#build-and-run-the-mock-inference-service-container)
     - [Adding GPU support](#adding-gpu-support)
@@ -358,7 +370,7 @@ For an example, the `write_dataset_to_bytes` function on [this Pydicom help page
 
 ##### DICOM structured report
 
-If your model returns a DICOM Structured Report then do the same as for secondary captures explained in the previous section, just change `'binary_type'` to `'dicom_structured_report'`.
+If your model returns a DICOM Structured Report then do the same as for secondary captures explained in the previous section, just change `'binary_type'` to `'dicom'`.
 
 ##### Returning DICOM conformance errors
 

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -42,7 +42,7 @@ def save_secondary_captures(json_response, output_folder_path, multipart_data):
     # Create DICOM files for secondary capture outputs
     for index, sc in enumerate(secondary_capture_parts):
         file_path = os.path.join(
-            output_folder_path, '{}{}.dcm'.format(sc['label'], index)
+            output_folder_path, 'sc_{}.dcm'.format(index)
         )
         with open(file_path, 'wb') as outfile:
             outfile.write(multipart_data.parts[index].content)

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -57,7 +57,7 @@ def upload_study_me(file_path,
                     send_study_size=False,
                     include_label_plots=False,
                     route='/',
-                    send_only_study_path=False,
+                    request_study_path='',
                     encoded_config_xml=''):
     file_dict = []
     headers = {'Content-Type': 'multipart/related; '}
@@ -106,9 +106,9 @@ def upload_study_me(file_path,
         file_dict.append((field, (filename, fo, 'application/octet-stream')))
 
     # Either send the path to the study in the request json,
-    # or append each dicom file to the request data based on send_only_study_path flag
-    if send_only_study_path:
-        request_json['studyPath'] = file_path
+    # or append each dicom file to the request data based on request_study_path flag
+    if request_study_path:
+        request_json['studyPath'] = request_study_path
     else:
         for image in images:
             try:
@@ -134,7 +134,7 @@ def upload_study_me(file_path,
 
     target = 'http://' + host + ':' + port + route
     print('Targeting inference request to: {}'.format(target))
-    if send_only_study_path:
+    if request_study_path:
         r = requests.post(target, json=request_json, headers=headers)
     else:
         file_dict.insert(0, ('request_json', ('request', json.dumps(request_json).encode('utf-8'), 'text/json')))
@@ -220,8 +220,8 @@ def parse_args():
         action='store_true')
     parser.add_argument("-c", "--inference_command", default=None, help="If set, overrides the 'inference_command' send in the request")
     parser.add_argument("-r", "--route", default='/', help="If set, the inference command is directed to the given route. Defaults to '/' route.")
-    parser.add_argument("--send_only_study_path", default=False, action='store_true',
-        help="If set, only the study path is sent to the inference SDK, rather than the study images being sent through HTTP. " \
+    parser.add_argument("--request_study_path", default='', type=str,
+        help="If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. " \
              "When set, ensure volumes are mounted appropriately in the inference docker container")
     parser.add_argument("-C", "--encoded_config_xml", default='', type=str, help="Optional encoded XML config to be passed as encodedConfigXML in request JSON")
     args = parser.parse_args()
@@ -248,5 +248,5 @@ if __name__ == '__main__':
                     args.send_study_size,
                     args.include_label_plots,
                     args.route,
-                    args.send_only_study_path,
+                    args.request_study_path,
                     args.encoded_config_xml)

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -53,7 +53,8 @@ def upload_study_me(file_path,
                     include_label_plots=False,
                     route='/',
                     request_study_path='',
-                    encoded_config_xml=''):
+                    encoded_config_xml='',
+                    plwmKey=''):
     file_dict = []
     headers = {'Content-Type': 'multipart/related; '}
 
@@ -69,6 +70,9 @@ def upload_study_me(file_path,
 
     if encoded_config_xml:
         request_json['encodedConfigXML'] = encoded_config_xml
+
+    if plwmKey:
+        request_json['plwmKey'] = plwmKey
 
     count = 0
     width = 0
@@ -194,6 +198,7 @@ def parse_args():
         help="If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. " \
              "When set, ensure volumes are mounted appropriately in the inference docker container")
     parser.add_argument("-C", "--encoded_config_xml", default='', type=str, help="Optional encoded XML config to be passed as encodedConfigXML in request JSON")
+    parser.add_argument("-K", "--plwmKey", default='', type=str, help="base64 encoded license key")
     args = parser.parse_args()
 
     return args
@@ -210,4 +215,5 @@ if __name__ == '__main__':
                     args.include_label_plots,
                     args.route,
                     args.request_study_path,
-                    args.encoded_config_xml)
+                    args.encoded_config_xml,
+                    args.plwmKey)

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -198,7 +198,7 @@ def parse_args():
         help="If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. " \
              "When set, ensure volumes are mounted appropriately in the inference docker container")
     parser.add_argument("-C", "--encoded_config_xml", default='', type=str, help="Optional encoded XML config to be passed as encodedConfigXML in request JSON")
-    parser.add_argument("-K", "--plwmKey", default='', type=str, help="base64 encoded license key")
+    parser.add_argument("-K", "--plwmKey", default='', type=str, help="Optional base64 encoded license key, only required for some models")
     args = parser.parse_args()
 
     return args

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -28,10 +28,6 @@ from utils import create_folder, DICOM_BINARY_TYPES
 
 from utils import load_image_data, sort_images
 
-SEGMENTATION_MODEL = "SEGMENTATION_MODEL"
-BOUNDING_BOX = "BOUNDING_BOX"
-CLASSIFICATION_MODEL = "CLASSIFICATION_MODEL"
-OTHER = "OTHER"
 
 def save_secondary_captures(json_response, output_folder_path, multipart_data):
     secondary_capture_parts = [
@@ -88,6 +84,7 @@ def upload_study_me(file_path,
     # or append each dicom file to the request data based on request_study_path flag
     if request_study_path:
         request_json['studyPath'] = request_study_path
+        headers['Content-Type'] = 'application/json'
     else:
         for image in images:
             try:

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -222,17 +222,15 @@ def parse_args():
     parser.add_argument("-c", "--inference_command", default='', help="If set, overrides the 'inference_command' send in the request")
     parser.add_argument("-r", "--route", default='/', help="If set, the inference command is directed to the given route. Defaults to '/' route.")
     parser.add_argument("--request_study_path", default='', type=str,
-        help="If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. " \
+        help="If set, only the given study path is sent to the inference SDK, rather than the study images being sent through HTTP. "
              "When set, ensure volumes are mounted appropriately in the inference docker container")
     parser.add_argument("--request_options", "-R",
                         metavar="KEY=VALUE",
                         nargs='+',
-                        help="Set a number of key-value pairs to be sent in the request JSON"
-                        "(do not put spaces before or after the = sign). "
+                        help="Set a number of key-value pairs to be sent in the request JSON (do not put spaces before or after the = sign). "
                         "If a value contains spaces, you should define "
-                        "it with double quotes: "
-                        'foo="this is a sentence". Note that '
-                        "values are always treated as strings.")
+                        "it with double quotes. Values are always treated as strings. "
+                        "e.g. --request_options foo=bar a=b greeting=\"hello there\"")
     args = parser.parse_args()
 
     return args

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -45,7 +45,7 @@ def save_secondary_captures(json_response, output_folder_path, multipart_data):
             output_folder_path, 'sc_{}.dcm'.format(index)
         )
         with open(file_path, 'wb') as outfile:
-            outfile.write(multipart_data.parts[index].content)
+            outfile.write(multipart_data.parts[index + 1].content)
 
 def upload_study_me(file_path,
                     model_type,

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -203,16 +203,7 @@ def parse_args():
 
 if __name__ == '__main__':
     args = parse_args()
-    if args.segmentation_model:
-        model_type = SEGMENTATION_MODEL
-    elif args.bounding_box_model:
-        model_type = BOUNDING_BOX
-    elif args.classification_model:
-        model_type = CLASSIFICATION_MODEL
-    else:
-        model_type = OTHER
     upload_study_me(args.input,
-                    model_type,
                     args.host,
                     args.port,
                     args.output,

--- a/inference-test-tool/run.py
+++ b/inference-test-tool/run.py
@@ -32,7 +32,7 @@ from utils import load_image_data, sort_images
 def save_secondary_captures(json_response, output_folder_path, multipart_data):
     secondary_capture_parts = [
         p for p in json_response['parts'] if p['binary_type'] in
-        ['dicom_structured_report', 'dicom_secondary_capture']
+        ['dicom', 'dicom_structured_report', 'dicom_secondary_capture']
     ]
 
     # Create DICOM files for secondary capture outputs

--- a/inference-test-tool/utils.py
+++ b/inference-test-tool/utils.py
@@ -11,7 +11,7 @@ import numpy as np
 import SimpleITK as sitk
 from PIL import Image
 
-DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom_structured_report'}
+DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report'}
 
 class DCM_Image:
     def __init__(self, dcm, path):

--- a/inference-test-tool/utils.py
+++ b/inference-test-tool/utils.py
@@ -11,7 +11,7 @@ import numpy as np
 import SimpleITK as sitk
 from PIL import Image
 
-DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom'}
+DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom_structured_report'}
 
 class DCM_Image:
     def __init__(self, dcm, path):

--- a/tests/test_2d_segmentation.py
+++ b/tests/test_2d_segmentation.py
@@ -13,7 +13,7 @@ class Test2DSegmentation(MockServerTestCase):
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
-        result = subprocess.run(['./send-inference-request.sh', '-s', '--host', '0.0.0.0', '-p',
+        result = subprocess.run(['./send-inference-request.sh', '--host', '0.0.0.0', '-p',
             self.inference_port, '-o', self.output_dir, '-i', self.input_dir] + self.additional_flags.split(),
             cwd='inference-test-tool', stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 

--- a/tests/test_3d_segmentation.py
+++ b/tests/test_3d_segmentation.py
@@ -13,7 +13,7 @@ class Test3DSegmentation(MockServerTestCase):
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
-        result = subprocess.run(['./send-inference-request.sh', '-s', '--host', '0.0.0.0', '-p',
+        result = subprocess.run(['./send-inference-request.sh', '--host', '0.0.0.0', '-p',
             self.inference_port, '-o', self.output_dir, '-i', self.input_dir] + self.additional_flags.split(),
             cwd='inference-test-tool', stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 

--- a/tests/test_bounding_boxes.py
+++ b/tests/test_bounding_boxes.py
@@ -12,10 +12,10 @@ class TestBoundingBox(MockServerTestCase):
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
-        result = subprocess.run(['./send-inference-request.sh', '-b', '--host', '0.0.0.0', '-p',
+        result = subprocess.run(['./send-inference-request.sh', '--host', '0.0.0.0', '-p',
             self.inference_port, '-o', self.output_dir, '-i', self.input_dir] + self.additional_flags.split(),
             cwd='inference-test-tool', stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
-        
+
         # Test that the command executed successfully
         self.check_success(result, command_name="Send inference request")
         self.assertEqual(result.returncode, 0)
@@ -30,10 +30,10 @@ class TestBoundingBox(MockServerTestCase):
         # Test JSON file contents
         file_path = os.path.join(self.inference_test_dir, self.output_dir, 'response.json')
         self.assertTrue(os.path.exists(file_path))
-        
+
         with open(file_path, 'r') as json_file:
             data = json.load(json_file)
-        
+
         self.assertIn('protocol_version', data)
         self.assertIn('parts', data)
         self.assertIn('bounding_boxes_2d', data)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -13,20 +13,20 @@ class TestClassification(MockServerTestCase):
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
-        result = subprocess.run(['./send-inference-request.sh', '-cl', '--host', '0.0.0.0', '-p',
+        result = subprocess.run(['./send-inference-request.sh', '--host', '0.0.0.0', '-p',
             self.inference_port, '-o', self.output_dir, '-i', self.input_dir] + self.additional_flags.split(),
             cwd='inference-test-tool', stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
-        
+
         # Test that the command executed successfully
         self.check_success(result, command_name="Send inference request")
         self.assertEqual(result.returncode, 0)
 
         output_files = os.listdir(os.path.join(self.inference_test_dir, self.output_dir))
 
-        # If .png files with labels should be generated export the following before 
-        # running tests: `export ARTERYS_TESTS_ADDITIONAL_FLAGS=-l` 
+        # If .png files with labels should be generated export the following before
+        # running tests: `export ARTERYS_TESTS_ADDITIONAL_FLAGS=-l`
         output_no_index = [name[name.index('_') + 1:] for name in output_files if name.endswith('.png')]
-        
+
         if '-l' in self.additional_flags or '-include_label_plots' in self.additional_flags:
             for name in input_files:
                 self.assertTrue((name + '.png') in output_no_index)
@@ -34,7 +34,7 @@ class TestClassification(MockServerTestCase):
         # Test JSON file contents
         file_path = os.path.join(self.inference_test_dir, self.output_dir, 'response.json')
         self.assertTrue(os.path.exists(file_path))
-        
+
         with open(file_path, 'r') as json_file:
             data = json.load(json_file)
 
@@ -56,7 +56,7 @@ class TestClassification(MockServerTestCase):
                 }
             },
         }
-        
+
         validate(data, schema=schema)
 
         print(term_colors.OKGREEN + "Classification model test succeeded!!", term_colors.ENDC)

--- a/tests/test_secondary_capture.py
+++ b/tests/test_secondary_capture.py
@@ -15,7 +15,7 @@ class TestSecondaryCapture(MockServerTestCase):
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
-        result = subprocess.run(['./send-inference-request.sh', '--segmentation_model', '--host=0.0.0.0', '--port=' +
+        result = subprocess.run(['./send-inference-request.sh', '--host=0.0.0.0', '--port=' +
             self.inference_port, '--output=' + self.output_dir, '--input=' + self.input_dir] + self.additional_flags.split(),
             cwd='inference-test-tool', stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 

--- a/tests/test_secondary_capture.py
+++ b/tests/test_secondary_capture.py
@@ -39,8 +39,7 @@ class TestSecondaryCapture(MockServerTestCase):
         output_folder_path = os.path.join(self.inference_test_dir, self.output_dir)
         output_files = os.listdir(output_folder_path)
         count_masks = len([f for f in output_files if f.startswith("sc_")])
-        # Test secondary capture and structured reports
-        secondary_capture_parts = [p for p in data["parts"] if p['binary_type'] in ['dicom_secondary_capture', 'dicom']]
+        secondary_capture_parts = [p for p in data["parts"] if p['binary_type'] == 'dicom_secondary_capture']
         self.assertEqual(count_masks, len(secondary_capture_parts))
 
         # Read and verify output secondary capture dicom files

--- a/tests/test_secondary_capture.py
+++ b/tests/test_secondary_capture.py
@@ -40,7 +40,7 @@ class TestSecondaryCapture(MockServerTestCase):
         output_files = os.listdir(output_folder_path)
         count_masks = len([f for f in output_files if f.startswith("sc_")])
         secondary_capture_parts = [p for p in data["parts"] if p['binary_type']
-                                   in {'dicom_secondary_capture', 'dicom_structured_report'}]
+                                   in {'dicom_secondary_capture', 'dicom', 'dicom_structured_report'}]
         self.assertEqual(count_masks, len(secondary_capture_parts))
 
         # Read and verify output secondary capture dicom files

--- a/tests/test_secondary_capture.py
+++ b/tests/test_secondary_capture.py
@@ -39,7 +39,8 @@ class TestSecondaryCapture(MockServerTestCase):
         output_folder_path = os.path.join(self.inference_test_dir, self.output_dir)
         output_files = os.listdir(output_folder_path)
         count_masks = len([f for f in output_files if f.startswith("sc_")])
-        secondary_capture_parts = [p for p in data["parts"] if p['binary_type'] == 'dicom_secondary_capture']
+        secondary_capture_parts = [p for p in data["parts"] if p['binary_type']
+                                   in {'dicom_secondary_capture', 'dicom_structured_report'}]
         self.assertEqual(count_masks, len(secondary_capture_parts))
 
         # Read and verify output secondary capture dicom files

--- a/tests/test_secondary_capture.py
+++ b/tests/test_secondary_capture.py
@@ -11,7 +11,7 @@ class TestSecondaryCapture(MockServerTestCase):
     input_dir = 'test_secondary_capture/'
     output_dir = 'test_secondary_capture_out/'
     command = '-s3D'
-    test_name = 'Secondary catpure test'
+    test_name = 'Secondary capture test'
 
     def testOutputFiles(self):
         input_files = os.listdir(os.path.join('tests/data', self.input_dir))
@@ -39,7 +39,8 @@ class TestSecondaryCapture(MockServerTestCase):
         output_folder_path = os.path.join(self.inference_test_dir, self.output_dir)
         output_files = os.listdir(output_folder_path)
         count_masks = len([f for f in output_files if f.startswith("sc_")])
-        secondary_capture_parts = [p for p in data["parts"] if p['binary_type'] == 'dicom_secondary_capture']
+        # Test secondary capture and structured reports
+        secondary_capture_parts = [p for p in data["parts"] if p['binary_type'] in ['dicom_secondary_capture', 'dicom']]
         self.assertEqual(count_masks, len(secondary_capture_parts))
 
         # Read and verify output secondary capture dicom files


### PR DESCRIPTION
- Instead of relying on flag to save specific model output. Save whatever output the model produces that matches schema.
- Replaced the inference-test-tool model type flags with a generic request_options field
- Added a --request_study_path flag to avoid sending DICOM images over HTTP, instead relying on mounted volumes
- Allow for dicom_structured_report binary type