### PR TITLE
Upgrade flask to fix upstream flask import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.12.48
-flask==1.1.2
+flask==2.0.3
 numpy==1.21.0
 pydicom==1.4.2
 pyyaml==5.4


### PR DESCRIPTION
Fixes upstream flask import error "ImportError: cannot import name 'json' from ..."

This seems to be occurring on any python3 and `flask==1.x` version combination:
```bash
docker run --rm python:3 bash -c "pip install flask==1.1.2 && python -c 'import flask'"
...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.10/site-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/usr/local/lib/python3.10/site-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.10/site-packages/itsdangerous/__init__.py)
```