### PR TITLE
[MICA-8249] update test case to be consistent with send-request

### DIFF
--- a/tests/test_2d_segmentation.py
+++ b/tests/test_2d_segmentation.py
@@ -52,7 +52,7 @@ class Test2DSegmentation(MockServerTestCase):
                not in DICOM_BINARY_TYPES]
         self.assertEqual(count_masks, len(segmentation_masks_parts))
 
-        for index, part in enumerate(data['parts']):
+        for index, part in enumerate(segmentation_masks_parts):
             self.assertIsInstance(part['label'], str)
             self.assertIsInstance(part['binary_type'], str)
             self.assertIn(part['binary_type'], ['heatmap', 'numeric_label_mask', 'dicom_secondary_capture', 'probability_mask', 'boolean_mask'],

--- a/tests/test_2d_segmentation.py
+++ b/tests/test_2d_segmentation.py
@@ -5,6 +5,7 @@ import numpy as np
 from .mock_server_test_case import MockServerTestCase
 from .utils import term_colors
 
+DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report', 'dicom_gsps'}
 class Test2DSegmentation(MockServerTestCase):
     input_dir = 'test_2d/'
     output_dir = 'test_2d_out/'
@@ -47,7 +48,9 @@ class Test2DSegmentation(MockServerTestCase):
         # Test if the amount of binary buffers is equals to the elements in `parts`
         output_files = os.listdir(os.path.join(self.inference_test_dir, self.output_dir))
         count_masks = len([f for f in output_files if f.startswith("output_masks_")])
-        self.assertEqual(count_masks, len(data['parts']))
+        segmentation_masks_parts = [part for part in data['parts'] if part['binary_type']
+               not in DICOM_BINARY_TYPES]
+        self.assertEqual(count_masks, len(segmentation_masks_parts))
 
         for index, part in enumerate(data['parts']):
             self.assertIsInstance(part['label'], str)

--- a/tests/test_2d_segmentation.py
+++ b/tests/test_2d_segmentation.py
@@ -3,9 +3,7 @@ import json
 import subprocess
 import numpy as np
 from .mock_server_test_case import MockServerTestCase
-from .utils import term_colors
-
-DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report', 'dicom_gsps'}
+from .utils import term_colors, DICOM_BINARY_TYPES
 class Test2DSegmentation(MockServerTestCase):
     input_dir = 'test_2d/'
     output_dir = 'test_2d_out/'

--- a/tests/test_3d_segmentation.py
+++ b/tests/test_3d_segmentation.py
@@ -3,9 +3,7 @@ import json
 import subprocess
 import numpy as np
 from .mock_server_test_case import MockServerTestCase
-from .utils import term_colors
-
-DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report', 'dicom_gsps'}
+from .utils import term_colors, DICOM_BINARY_TYPES
 class Test3DSegmentation(MockServerTestCase):
     input_dir = 'test_3d/'
     output_dir = 'test_3d_out/'

--- a/tests/test_3d_segmentation.py
+++ b/tests/test_3d_segmentation.py
@@ -5,6 +5,7 @@ import numpy as np
 from .mock_server_test_case import MockServerTestCase
 from .utils import term_colors
 
+DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report', 'dicom_gsps'}
 class Test3DSegmentation(MockServerTestCase):
     input_dir = 'test_3d/'
     output_dir = 'test_3d_out/'
@@ -48,7 +49,7 @@ class Test3DSegmentation(MockServerTestCase):
         output_files = os.listdir(output_folder_path)
         count_masks = len([f for f in output_files if f.startswith("output_masks_")])
         segmentation_masks_parts = [part for part in data['parts'] if part['binary_type']
-                in ['probability_mask', 'boolean_mask', 'numeric_label_mask']]
+               not in DICOM_BINARY_TYPES]
         self.assertEqual(count_masks, len(segmentation_masks_parts))
 
         for index, part in enumerate(segmentation_masks_parts):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,3 +8,5 @@ class term_colors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+
+DICOM_BINARY_TYPES = {'dicom_secondary_capture', 'dicom', 'dicom_structured_report', 'dicom_gsps'}


### PR DESCRIPTION
Update 3d-segmentation and 2d-segmentation test to explicitly select masks and to be consistent with the send request tool when selecting mask